### PR TITLE
Upload creates project metadata annotation script

### DIFF
--- a/lando_util/tests/test_upload.py
+++ b/lando_util/tests/test_upload.py
@@ -82,6 +82,9 @@ class TestUploadFunctions(TestCase):
         mock_outfile = Mock()
         mock_project = Mock()
         mock_project.id = '123'
+        mock_readme_file = Mock()
+        mock_readme_file.id = '456'
+        mock_project.get_child_for_path.return_value = mock_readme_file
         mock_dds_client.create_project.return_value = mock_project
         mock_project_upload.return_value.needs_to_upload.return_value = True
         mock_project_upload.return_value.get_differences_summary.return_value = 'There are 2 files to upload.'
@@ -93,8 +96,9 @@ class TestUploadFunctions(TestCase):
             call('There are 2 files to upload.'),
             call('Uploading')])
         mock_dds_client.create_project.assert_called_with('myProject', description='myProject')
-        mock_create_annotate_project_details_scripts.assert_called_with('123', 'TODO', mock_outfile)
+        mock_create_annotate_project_details_scripts.assert_called_with('123', '456', mock_outfile)
         mock_share_project.assert_called_with(mock_dds_client, '123', mock_upload_list)
+        mock_project.get_child_for_path.assert_called_with('results/docs/README.md')
 
     @patch("lando_util.upload.ProjectUpload")
     @patch("lando_util.upload.create_annotate_project_details_script")

--- a/lando_util/tests/test_upload.py
+++ b/lando_util/tests/test_upload.py
@@ -9,6 +9,7 @@ class TestUploadList(TestCase):
     def test_constructor_minimal_data(self, mock_json):
         mock_json.load.return_value = {
             "destination": "myproject",
+            "readme_file_path": "results/docs/README.md",
             "paths": ["/data/results"],
             "share": {
                 "dds_user_ids": ["123","456"]

--- a/lando_util/tests/test_upload.py
+++ b/lando_util/tests/test_upload.py
@@ -1,7 +1,7 @@
 import os
 from unittest import TestCase
 from unittest.mock import patch, Mock, call
-from lando_util.upload import UploadList, write_results, share_project, upload_files
+from lando_util.upload import UploadList, write_results_env_vars, share_project, upload_files
 
 
 class TestUploadList(TestCase):
@@ -40,10 +40,10 @@ class TestUploadList(TestCase):
 
 
 class TestUploadFunctions(TestCase):
-    def test_write_results(self):
+    def test_write_results_env_vars(self):
         mock_outfile = Mock()
-        write_results(project_id='123', outfile=mock_outfile)
-        mock_outfile.write.assert_called_with('{"project_id": "123", "readme_file_id": "TODO"}')
+        write_results_env_vars(project_id='123', readme_file_id='456', outfile=mock_outfile)
+        mock_outfile.write.assert_called_with('project_id=123\nreadme_file_id=456\n')
 
     @patch('lando_util.upload.RemoteStore')
     @patch('lando_util.upload.D4S2Project')
@@ -69,10 +69,10 @@ class TestUploadFunctions(TestCase):
         ])
 
     @patch("lando_util.upload.ProjectUpload")
-    @patch("lando_util.upload.write_results")
+    @patch("lando_util.upload.write_results_env_vars")
     @patch("lando_util.upload.share_project")
     @patch("lando_util.upload.click")
-    def test_upload_files(self, mock_click, mock_share_project, mock_write_results, mock_project_upload):
+    def test_upload_files(self, mock_click, mock_share_project, mock_write_results_env_vars, mock_project_upload):
         mock_dds_client = Mock()
         mock_upload_list = Mock(
             destination="myProject", paths=["/data/results"],
@@ -92,14 +92,15 @@ class TestUploadFunctions(TestCase):
             call('There are 2 files to upload.'),
             call('Uploading')])
         mock_dds_client.create_project.assert_called_with('myProject', description='myProject')
-        mock_write_results.assert_called_with('123', mock_outfile)
+        mock_write_results_env_vars.assert_called_with('123', 'TODO', mock_outfile)
         mock_share_project.assert_called_with(mock_dds_client, '123', mock_upload_list)
 
     @patch("lando_util.upload.ProjectUpload")
-    @patch("lando_util.upload.write_results")
+    @patch("lando_util.upload.write_results_env_vars")
     @patch("lando_util.upload.share_project")
     @patch("lando_util.upload.click")
-    def test_upload_files_no_data(self, mock_click, mock_share_project, mock_write_results, mock_project_upload):
+    def test_upload_files_no_data(self, mock_click, mock_share_project, mock_write_results_env_vars,
+                                  mock_project_upload):
         mock_dds_client = Mock()
         mock_upload_list = Mock(
             destination="myProject", paths=["/data/results"],
@@ -121,5 +122,5 @@ class TestUploadFunctions(TestCase):
             call('There are 0 files to upload.')])
         mock_dds_client.create_project.assert_called_with('myProject', description='myProject')
         mock_dds_client.create_project.return_value.delete.assert_called_with()
-        mock_write_results.assert_not_called()
+        mock_write_results_env_vars.assert_not_called()
         mock_share_project.assert_not_called()

--- a/lando_util/tests/test_upload.py
+++ b/lando_util/tests/test_upload.py
@@ -26,6 +26,7 @@ class TestUploadList(TestCase):
     def test_constructor_optional_values(self, mock_json):
         mock_json.load.return_value = {
             "destination": "myproject",
+            "readme_file_path": "results/docs/README.md",
             "paths": ["/data/results"],
             "share": {
                 "dds_user_ids": ["123","456"],
@@ -79,6 +80,7 @@ class TestUploadFunctions(TestCase):
             destination="myProject", paths=["/data/results"],
             share_auth_role='project_admin', share_user_message='Hey')
         mock_upload_list.share_dds_user_ids = ['456', '789']
+        mock_upload_list.readme_file_path = 'somepath.md'
         mock_outfile = Mock()
         mock_project = Mock()
         mock_project.id = '123'
@@ -98,7 +100,7 @@ class TestUploadFunctions(TestCase):
         mock_dds_client.create_project.assert_called_with('myProject', description='myProject')
         mock_create_annotate_project_details_scripts.assert_called_with('123', '456', mock_outfile)
         mock_share_project.assert_called_with(mock_dds_client, '123', mock_upload_list)
-        mock_project.get_child_for_path.assert_called_with('results/docs/README.md')
+        mock_project.get_child_for_path.assert_called_with('somepath.md')
 
     @patch("lando_util.upload.ProjectUpload")
     @patch("lando_util.upload.create_annotate_project_details_script")

--- a/lando_util/tests/test_upload.py
+++ b/lando_util/tests/test_upload.py
@@ -1,10 +1,9 @@
-import os
 from unittest import TestCase
 from unittest.mock import patch, Mock, call
-from lando_util.upload import UploadList, create_annotate_project_details_script, share_project, upload_files
+from lando_util.upload import Settings, NothingToUploadException, UploadUtil, main
 
 
-class TestUploadList(TestCase):
+class TestSettings(TestCase):
     @patch('lando_util.upload.json')
     def test_constructor_minimal_data(self, mock_json):
         mock_json.load.return_value = {
@@ -16,12 +15,12 @@ class TestUploadList(TestCase):
             }
         }
         mock_cmdfile = Mock()
-        upload_list = UploadList(mock_cmdfile)
-        self.assertEqual(upload_list.destination, "myproject")
-        self.assertEqual(upload_list.paths, ["/data/results"])
-        self.assertEqual(upload_list.share_dds_user_ids, ["123","456"])
-        self.assertEqual(upload_list.share_auth_role, "project_admin")
-        self.assertEqual(upload_list.share_user_message, "Bespin job results.")
+        settings = Settings(mock_cmdfile)
+        self.assertEqual(settings.destination, "myproject")
+        self.assertEqual(settings.paths, ["/data/results"])
+        self.assertEqual(settings.share_dds_user_ids, ["123","456"])
+        self.assertEqual(settings.share_auth_role, "project_admin")
+        self.assertEqual(settings.share_user_message, "Bespin job results.")
 
     @patch('lando_util.upload.json')
     def test_constructor_optional_values(self, mock_json):
@@ -36,99 +35,114 @@ class TestUploadList(TestCase):
             },
         }
         mock_cmdfile = Mock()
-        upload_list = UploadList(mock_cmdfile)
-        self.assertEqual(upload_list.share_auth_role, "project_downloader")
-        self.assertEqual(upload_list.share_user_message, "Other stuff")
+        settings = Settings(mock_cmdfile)
+        self.assertEqual(settings.share_auth_role, "project_downloader")
+        self.assertEqual(settings.share_user_message, "Other stuff")
 
 
-class TestUploadFunctions(TestCase):
-    def test_create_annotate_project_details_script(self):
-        mock_outfile = Mock()
-        create_annotate_project_details_script(project_id='123', readme_file_id='456', outfile=mock_outfile)
-        mock_outfile.write.assert_called_with('kubectl annotate pod $MY_POD_NAME project_id=123 readme_file_id=456')
+@patch('lando_util.upload.Settings')
+@patch('lando_util.upload.DukeDSClient')
+class TestUploadUtil(TestCase):
+    def test_create_project(self, mock_duke_ds_client, mock_settings):
+        mock_settings.return_value.destination = 'myproject'
+        util = UploadUtil(Mock())
+        project = util.create_project()
+        self.assertEqual(project, util.dds_client.create_project.return_value)
+        util.dds_client.create_project.assert_called_with('myproject', description='myproject')
+
+    @patch('lando_util.upload.ProjectUpload')
+    @patch('lando_util.upload.ProjectNameOrId')
+    @patch('lando_util.upload.click')
+    def test_upload_files(self, mock_click, mock_project_name_or_id, mock_project_upload, mock_duke_ds_client,
+                          mock_settings):
+        util = UploadUtil(Mock())
+        mock_project = Mock()
+        mock_project.id = '123456'
+        mock_project_upload.return_value.needs_to_upload.return_value = True
+        mock_project_upload.return_value.get_differences_summary.return_value = 'There are 2 files to upload.'
+        util.upload_files(project=mock_project)
+        mock_project_upload.assert_called_with(
+            mock_duke_ds_client.return_value.dds_connection.config,
+            mock_project_name_or_id.create_from_project_id.return_value,
+            mock_settings.return_value.paths
+        )
+        mock_project_name_or_id.create_from_project_id.assert_called_with('123456')
+        mock_click.echo.assert_has_calls([
+            call('There are 2 files to upload.'),
+            call('Uploading')
+        ])
+
+    @patch('lando_util.upload.ProjectUpload')
+    @patch('lando_util.upload.click')
+    def test_upload_files_no_files_found(self, mock_click, mock_project_upload, mock_duke_ds_client, mock_settings):
+        util = UploadUtil(Mock())
+        mock_project = Mock()
+        mock_project_upload.return_value.get_differences_summary.return_value = 'There are 0 files to upload.'
+        mock_project_upload.return_value.needs_to_upload.return_value = False
+        with self.assertRaises(NothingToUploadException):
+            util.upload_files(project=mock_project)
+        mock_click.echo.assert_called_with('There are 0 files to upload.')
 
     @patch('lando_util.upload.RemoteStore')
     @patch('lando_util.upload.D4S2Project')
-    def test_share_project(self, mock_d4s2_project, mock_remote_store):
-        mock_dds_client = Mock()
-        share_project_id = '123'
-        mock_upload_list = Mock(
-            destination="myProject", paths=["/data/results"],
-            share_auth_role='project_admin', share_user_message='Hey')
-        mock_upload_list.share_dds_user_ids = ['456', '789']
-        share_project(mock_dds_client, share_project_id, mock_upload_list)
+    def test_share_project(self, mock_d4s2_project, mock_remote_store, mock_duke_ds_client, mock_settings):
+        mock_settings.return_value.share_dds_user_ids = ['444', '555']
+        mock_settings.return_value.share_auth_role = 'somerole'
+        mock_settings.return_value.share_user_message = 'someMessage'
+        util = UploadUtil(Mock())
+        mock_project = Mock()
+        mock_project.id = '111'
 
-        mock_remote_store.return_value.fetch_remote_project_by_id.assert_called_with('123')
+        util.share_project(mock_project)
+
+        mock_remote_store.return_value.fetch_remote_project_by_id.assert_called_with('111')
         mock_remote_project = mock_remote_store.return_value.fetch_remote_project_by_id.return_value
         mock_remote_user = mock_remote_store.return_value.fetch_user.return_value
+        mock_d4s2_project.return_value.share.assert_called_with(
+            mock_remote_project,
+            mock_remote_user,
+            auth_role='somerole',
+            force_send=True,
+            user_message='someMessage'
+        )
         mock_remote_store.return_value.fetch_user.assert_has_calls([
-            call("456"), call("789")
+            call('444'),
+            call('555'),
         ])
 
-        mock_d4s2_project.return_value.share.assert_has_calls([
-            call(mock_remote_project, mock_remote_user, auth_role='project_admin', force_send=True, user_message='Hey'),
-            call(mock_remote_project, mock_remote_user, auth_role='project_admin', force_send=True, user_message='Hey'),
-        ])
-
-    @patch("lando_util.upload.ProjectUpload")
-    @patch("lando_util.upload.create_annotate_project_details_script")
-    @patch("lando_util.upload.share_project")
-    @patch("lando_util.upload.click")
-    def test_upload_files(self, mock_click, mock_share_project, mock_create_annotate_project_details_scripts,
-                          mock_project_upload):
-        mock_dds_client = Mock()
-        mock_upload_list = Mock(
-            destination="myProject", paths=["/data/results"],
-            share_auth_role='project_admin', share_user_message='Hey')
-        mock_upload_list.share_dds_user_ids = ['456', '789']
-        mock_upload_list.readme_file_path = 'somepath.md'
-        mock_outfile = Mock()
+    def test_create_annotate_project_details_script(self, mock_duke_ds_client, mock_settings):
+        util = UploadUtil(Mock())
         mock_project = Mock()
-        mock_project.id = '123'
+        mock_project.id = '888'
         mock_readme_file = Mock()
-        mock_readme_file.id = '456'
+        mock_readme_file.id = '999'
         mock_project.get_child_for_path.return_value = mock_readme_file
-        mock_dds_client.create_project.return_value = mock_project
-        mock_project_upload.return_value.needs_to_upload.return_value = True
-        mock_project_upload.return_value.get_differences_summary.return_value = 'There are 2 files to upload.'
-
-        upload_files(mock_dds_client, mock_upload_list, mock_outfile)
-
-        mock_click.echo.assert_has_calls([
-            call('Uploading 1 paths to myProject.'),
-            call('There are 2 files to upload.'),
-            call('Uploading')])
-        mock_dds_client.create_project.assert_called_with('myProject', description='myProject')
-        mock_create_annotate_project_details_scripts.assert_called_with('123', '456', mock_outfile)
-        mock_share_project.assert_called_with(mock_dds_client, '123', mock_upload_list)
-        mock_project.get_child_for_path.assert_called_with('somepath.md')
-
-    @patch("lando_util.upload.ProjectUpload")
-    @patch("lando_util.upload.create_annotate_project_details_script")
-    @patch("lando_util.upload.share_project")
-    @patch("lando_util.upload.click")
-    def test_upload_files_no_data(self, mock_click, mock_share_project, mock_create_annotate_project_details_script,
-                                  mock_project_upload):
-        mock_dds_client = Mock()
-        mock_upload_list = Mock(
-            destination="myProject", paths=["/data/results"],
-            share_auth_role='project_admin', share_user_message='Hey')
-        mock_upload_list.share_dds_user_ids = ['456', '789']
         mock_outfile = Mock()
-        mock_project = Mock()
-        mock_project.id = '123'
-        mock_dds_client.create_project.return_value = mock_project
-        mock_project_upload.return_value.needs_to_upload.return_value = False
-        mock_project_upload.return_value.get_differences_summary.return_value = 'There are 0 files to upload.'
+        util.create_annotate_project_details_script(mock_project, mock_outfile)
+        mock_outfile.write.assert_called_with('kubectl annotate pod $MY_POD_NAME project_id=888 readme_file_id=999')
 
-        with self.assertRaises(ValueError) as raised_exception:
-            upload_files(mock_dds_client, mock_upload_list, mock_outfile)
-        self.assertEqual(str(raised_exception.exception), 'Error: No files or folders found to upload.')
 
-        mock_click.echo.assert_has_calls([
-            call('Uploading 1 paths to myProject.'),
-            call('There are 0 files to upload.')])
-        mock_dds_client.create_project.assert_called_with('myProject', description='myProject')
-        mock_dds_client.create_project.return_value.delete.assert_called_with()
-        mock_create_annotate_project_details_script.assert_not_called()
-        mock_share_project.assert_not_called()
+class TestMain(TestCase):
+    @patch('lando_util.upload.UploadUtil')
+    def test_main(self, mock_upload_util):
+        mock_cmdfile = Mock()
+        mock_outfile = Mock()
+
+        main.callback(mock_cmdfile, mock_outfile)
+
+        mock_upload_util.assert_called_with(mock_cmdfile)
+        mock_upload_util.return_value.create_project.assert_called_with()
+        mock_project = mock_upload_util.return_value.create_project.return_value
+        mock_upload_util.return_value.share_project.assert_called_with(mock_project)
+        mock_upload_util.return_value.create_annotate_project_details_script.assert_called_with(
+            mock_project, mock_outfile)
+
+    @patch('lando_util.upload.UploadUtil')
+    def test_main_nothing_to_upload(self, mock_upload_util):
+        mock_cmdfile = Mock()
+        mock_outfile = Mock()
+        mock_upload_util.return_value.upload_files.side_effect = NothingToUploadException("Nothing to upload")
+
+        with self.assertRaises(NothingToUploadException):
+            main.callback(mock_cmdfile, mock_outfile)
+        mock_upload_util.return_value.create_project.return_value.delete.assert_called_with()

--- a/lando_util/upload.py
+++ b/lando_util/upload.py
@@ -10,7 +10,7 @@ class UploadList(object):
     def __init__(self, cmdfile):
         data = json.load(cmdfile)
         self.destination = data['destination']
-        self.readme_file_path = data.get['readme_file_path']
+        self.readme_file_path = data['readme_file_path']
         self.paths = data['paths']
         share = data.get('share', {})
         self.share_dds_user_ids = share['dds_user_ids']

--- a/lando_util/upload.py
+++ b/lando_util/upload.py
@@ -5,13 +5,12 @@ from ddsc.core.upload import ProjectUpload
 from ddsc.core.remotestore import RemoteStore, ProjectNameOrId
 from ddsc.core.d4s2 import D4S2Project
 
-README_FILE_LOCATION = 'results/docs/README.md'
-
 
 class UploadList(object):
     def __init__(self, cmdfile):
         data = json.load(cmdfile)
         self.destination = data['destination']
+        self.readme_file_path = data.get['readme_file_path']
         self.paths = data['paths']
         share = data.get('share', {})
         self.share_dds_user_ids = share['dds_user_ids']
@@ -51,7 +50,7 @@ def upload_files(dds_client, upload_list, outfile):
     if project_upload.needs_to_upload():
         click.echo("Uploading")
         project_upload.run()
-        readme_file = project.get_child_for_path(README_FILE_LOCATION)
+        readme_file = project.get_child_for_path(upload_list.readme_file_path)
         create_annotate_project_details_script(project.id, readme_file.id, outfile)
         share_project(dds_client, project.id, upload_list)
     else:

--- a/lando_util/upload.py
+++ b/lando_util/upload.py
@@ -17,12 +17,9 @@ class UploadList(object):
         self.share_user_message = share.get('user_message', 'Bespin job results.')
 
 
-def write_results(project_id, outfile):
+def write_results_env_vars(project_id, readme_file_id, outfile):
     click.echo("Writing project id {} to {}".format(project_id, outfile.name))
-    contents = json.dumps({
-        'project_id': project_id,
-        'readme_file_id': 'TODO',
-    })
+    contents = "project_id={}\nreadme_file_id={}\n".format(project_id, readme_file_id)
     outfile.write(contents)
     outfile.close()
 
@@ -51,7 +48,7 @@ def upload_files(dds_client, upload_list, outfile):
     if project_upload.needs_to_upload():
         click.echo("Uploading")
         project_upload.run()
-        write_results(project.id, outfile)
+        write_results_env_vars(project.id, 'TODO', outfile)
         share_project(dds_client, project.id, upload_list)
     else:
         project.delete()

--- a/lando_util/upload.py
+++ b/lando_util/upload.py
@@ -5,6 +5,8 @@ from ddsc.core.upload import ProjectUpload
 from ddsc.core.remotestore import RemoteStore, ProjectNameOrId
 from ddsc.core.d4s2 import D4S2Project
 
+README_FILE_LOCATION = 'results/docs/README.md'
+
 
 class UploadList(object):
     def __init__(self, cmdfile):
@@ -49,7 +51,8 @@ def upload_files(dds_client, upload_list, outfile):
     if project_upload.needs_to_upload():
         click.echo("Uploading")
         project_upload.run()
-        create_annotate_project_details_script(project.id, 'TODO', outfile)
+        readme_file = project.get_child_for_path(README_FILE_LOCATION)
+        create_annotate_project_details_script(project.id, readme_file.id, outfile)
         share_project(dds_client, project.id, upload_list)
     else:
         project.delete()

--- a/lando_util/upload.py
+++ b/lando_util/upload.py
@@ -17,9 +17,10 @@ class UploadList(object):
         self.share_user_message = share.get('user_message', 'Bespin job results.')
 
 
-def write_results_env_vars(project_id, readme_file_id, outfile):
-    click.echo("Writing project id {} to {}".format(project_id, outfile.name))
-    contents = "project_id={}\nreadme_file_id={}\n".format(project_id, readme_file_id)
+def create_annotate_project_details_script(project_id, readme_file_id, outfile):
+    click.echo("Writing annotate project details script project_id:{} readme_file_id:{} to {}".format(
+        project_id, readme_file_id, outfile.name))
+    contents = "kubectl annotate pod $MY_POD_NAME project_id={} readme_file_id={}".format(project_id, readme_file_id)
     outfile.write(contents)
     outfile.close()
 
@@ -48,7 +49,7 @@ def upload_files(dds_client, upload_list, outfile):
     if project_upload.needs_to_upload():
         click.echo("Uploading")
         project_upload.run()
-        write_results_env_vars(project.id, 'TODO', outfile)
+        create_annotate_project_details_script(project.id, 'TODO', outfile)
         share_project(dds_client, project.id, upload_list)
     else:
         project.delete()


### PR DESCRIPTION
The upload operation now creates a script that uses kubectl to annotate the current pod with annotations about the DukeDS project id and readme file id for the uploaded data.
Script:
```
kubectl annotate pod $MY_POD_NAME project_id=<project_id> readme_file_id=<file_id>
```
This script expects the MY_POD_NAME environment variable to contain the name of the pod to annotate with this data.

Adds `readme_file_path` config file parameter that should contain a path to the readme file that the data service can use to lookup the unique id for that file. 
