### PR TITLE
Setup CI to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2.1
+
+orbs:
+    hello: circleci/hello-build@0.0.5
+
+workflows:
+    "Hello Workflow":
+        jobs:
+          - hello/hello-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
     executors:
       default:
         docker:
-          - image: circleci/python:3.7
+          - image: circleci/python:3.6
     commands:
       update_venv:
         steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,36 @@ orbs:
         docker:
           - image: circleci/python:3.7
     commands:
-      dospecialthings:
+      update_venv:
         steps:
-          - run: echo "We will now do special things"
+          - restore_cache:
+            key: dependency-cache-{{ checksum "setup.py" }}
+          - run:
+            name: install python dependencies
+            command: |
+              python3 -m venv venv
+              . venv/bin/activate
+              python setup.py install
+          - save_cache:
+            key: dependency-cache-{{ checksum "setup.py" }}
+            paths:
+              - "venv"
+      run_tests:
+        steps:
+        - run:
+            name: run tests
+            command: |
+              . venv/bin/activate
+              python setup.py test
+
     jobs:
-      myjob:
+      pytest:
         executor: default
         steps:
-          - dospecialthings
+          - update_venv
+          - run_tests
 
 workflows:
     "Hello Workflow":
         jobs:
-          - python/myjob
+          - python/pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ orbs:
       pytest:
         executor: default
         steps:
+          - checkout
           - update_venv
           - run_tests
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,23 +24,31 @@ orbs:
                paths:
                  - venv
       run_tests:
+        parameters:
+          test_command:
+            description: command to run for tests
+            type: string
         steps:
           - run:
               command: |
                 . venv/bin/activate
-                python setup.py test
+                <<parameters.test_command>>
     jobs:
       pytest:
         parameters:
           venv_checksum_filename:
             description: Name of the file we checksum to save venv cache
             type: string
+          test_command:
+            description: command to run for tests
+            type: string
         executor: default
         steps:
           - checkout
           - update_venv:
               venv_checksum_filename: <<parameters.venv_checksum_filename>>
-          - run_tests
+          - run_tests:
+              test_command: <<parameters.test_command>>
 
 version: 2.1
 workflows:
@@ -48,4 +56,5 @@ workflows:
     jobs:
       - python/pytest:
           venv_checksum_filename: setup.py
+          test_command: python setup.py test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,22 @@
 version: 2.1
 
-
 orbs:
-  python: chariot/python@0.0.1
+  python:
+    executors:
+      default:
+        docker:
+          - image: circleci/python:3.7
+    commands:
+      dospecialthings:
+        steps:
+          - run: echo "We will now do special things"
+    jobs:
+      myjob:
+        executor: default
+        steps:
+          - dospecialthings
 
 workflows:
     "Hello Workflow":
         jobs:
-          - python/pytest
+          - python/myjob

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ orbs:
           venv_checksum_filename:
             description: Name of the file we checksum to save venv cache
             type: string
+          install_command:
+            description: Command to run to install dependencies
+            type: string
         steps:
            - restore_cache:
                key: dependency-cache-{{ checksum "<<parameters.venv_checksum_filename>>" }}
@@ -18,7 +21,7 @@ orbs:
                command: |
                  python3 -m venv venv
                  . venv/bin/activate
-                 python setup.py install
+                 <<parameters.install_command>>
            - save_cache:
                key: dependency-cache-{{ checksum "<<parameters.venv_checksum_filename>>" }}
                paths:
@@ -39,6 +42,9 @@ orbs:
           venv_checksum_filename:
             description: Name of the file we checksum to save venv cache
             type: string
+          install_command:
+            description: Command to run to install dependencies
+            type: string
           test_command:
             description: command to run for tests
             type: string
@@ -47,6 +53,7 @@ orbs:
           - checkout
           - update_venv:
               venv_checksum_filename: <<parameters.venv_checksum_filename>>
+              install_command: <<parameters.install_command>>
           - run_tests:
               test_command: <<parameters.test_command>>
 
@@ -56,5 +63,6 @@ workflows:
     jobs:
       - python/pytest:
           venv_checksum_filename: setup.py
+          install_command: python setup.py install
           test_command: python setup.py test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,11 @@ orbs:
           - image: circleci/python:3.6
     commands:
       update_venv:
+        parameters:
+          venv_checksum_filename:
+            description: Name of the file we checksum to save venv cache
+            type: string
+            default: setup.py
         steps:
            - restore_cache:
                key: dependency-cache-{{ checksum "setup.py" }}
@@ -19,7 +24,7 @@ orbs:
                key: dependency-cache-{{ checksum "setup.py" }}
                paths:
                  - "venv"
-      run_tests:
+      run_setup_tests:
         steps:
           - run:
               command: |
@@ -27,10 +32,16 @@ orbs:
                 python setup.py test
     jobs:
       pytest:
+        parameters:
+          venv_checksum_filename:
+            description: Name of the file we checksum to save venv cache
+            type: string
+            default: setup.py
         executor: default
         steps:
           - checkout
           - update_venv
+            venv_checksum_filename: setup.no
           - run_tests
 
 version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,9 @@ version: 2.1
 
 
 orbs:
-    hello: circleci/hello-build@0.0.5
+  python: chariot/python@0.0.1
 
 workflows:
     "Hello Workflow":
         jobs:
-          - hello/hello-build
+          - python/pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,9 @@ orbs:
           venv_checksum_filename:
             description: Name of the file we checksum to save venv cache
             type: string
-            default: setup.py
         steps:
            - restore_cache:
-               key: dependency-cache-{{ checksum "setup.py" }}
+               key: dependency-cache-{{ checksum "<<parameters.venv_checksum_filename>>" }}
            - run:
                name: install python dependencies
                command: |
@@ -21,10 +20,10 @@ orbs:
                  . venv/bin/activate
                  python setup.py install
            - save_cache:
-               key: dependency-cache-{{ checksum "setup.py" }}
+               key: dependency-cache-{{ checksum "<<parameters.venv_checksum_filename>>" }}
                paths:
-                 - "venv"
-      run_setup_tests:
+                 - venv
+      run_tests:
         steps:
           - run:
               command: |
@@ -36,16 +35,17 @@ orbs:
           venv_checksum_filename:
             description: Name of the file we checksum to save venv cache
             type: string
-            default: setup.py
         executor: default
         steps:
           - checkout
-          - update_venv
-            venv_checksum_filename: setup.no
+          - update_venv:
+              venv_checksum_filename: <<parameters.venv_checksum_filename>>
           - run_tests
 
 version: 2.1
 workflows:
   main:
     jobs:
-      - python/pytest
+      - python/pytest:
+          venv_checksum_filename: setup.py
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,3 @@
-version: 2.1
-
 orbs:
   python:
     executors:
@@ -9,26 +7,24 @@ orbs:
     commands:
       update_venv:
         steps:
-          - restore_cache:
-            key: dependency-cache-{{ checksum "setup.py" }}
-          - run:
-            name: install python dependencies
-            command: |
-              python3 -m venv venv
-              . venv/bin/activate
-              python setup.py install
-          - save_cache:
-            key: dependency-cache-{{ checksum "setup.py" }}
-            paths:
-              - "venv"
+           - restore_cache:
+               key: dependency-cache-{{ checksum "setup.py" }}
+           - run:
+               name: install python dependencies
+               command: |
+                 python3 -m venv venv
+                 . venv/bin/activate
+                 python setup.py install
+           - save_cache:
+               key: dependency-cache-{{ checksum "setup.py" }}
+               paths:
+                 - "venv"
       run_tests:
         steps:
-        - run:
-            name: run tests
-            command: |
-              . venv/bin/activate
-              python setup.py test
-
+          - run:
+              command: |
+                . venv/bin/activate
+                python setup.py test
     jobs:
       pytest:
         executor: default
@@ -36,7 +32,8 @@ orbs:
           - update_venv
           - run_tests
 
+version: 2.1
 workflows:
-    "Hello Workflow":
-        jobs:
-          - python/pytest
+  main:
+    jobs:
+      - python/pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 
+
 orbs:
     hello: circleci/hello-build@0.0.5
 


### PR DESCRIPTION
Uses inline circleci orbs to run tests.
By itself it isn't much simpler than the normal circleci boilerplate.
Looked at the existing python orbs but none worked for my use case: https://circleci.com/orbs/registry/?query=python&filterBy=all

Orbs docs: https://circleci.com/docs/2.0/using-orbs/

In the future we can publish our own python orbs and the top part of the circle config file can be deleted.