### PR TITLE
Support zipped workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lando-util
 Utilities used by [k8s.lando](https://github.com/Duke-GCB/lando/blob/master/lando/k8s/README.md) related to running a workflow.
-- download files from DukeDS, URLs, or with hard coded content
+- stage data from DukeDS, URLs, hard coded content, etc
 - organize output project directory
 - upload a directory to DukeDS
 
@@ -15,12 +15,12 @@ This logic was broken out of [lando_worker](https://github.com/Duke-GCB/lando/tr
 python setup.py install
 ```
 
-## Download Files
-Users must first create a json command file with a list of items to download.
+## Stage Data
+Users must first create a json command file with a list of items to stage.
 
-Run the download command:
+Run the stagedata command:
 ```
-python -m lando_util.download <COMMAND_FILE> [DOWNLOADED_ITEMS_METADATA_FILE]
+python -m lando_util.stagedata <COMMAND_FILE> [DOWNLOADED_ITEMS_METADATA_FILE]
 ```
 DOWNLOADED_ITEMS_METADATA_FILE is an optional argument that will save metadata about downloaded DukeDS files.
 
@@ -38,6 +38,7 @@ Supported values for type are:
 - DukeDS - The `source` field must be a DukeDS file UUID.
 - url - The `source` field must be a url of a file to download.
 - write - The `source` field must be data to be writen to a file.
+- unzip - Unzip `source` field to `dest`.
 
 
 ## Organize Output Project

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Example JSON command file:
 {
     "items": [
         {"type": "DukeDS", "source": "<DukeDS file id>", "dest": "<path to save file to>"},
-        {"type": "url", "source": "<url of file to download>", "dest": "<path to save file to>"},
+        {"type": "url", "source": "<url of file to download>", "dest": "<path to save file to>", "unzip_to": "<path to unzip file to>"},
         {"type": "write", "source": "<data to write>", "dest": "<path to write data to>"},
     ]
 }
@@ -38,7 +38,8 @@ Supported values for type are:
 - DukeDS - The `source` field must be a DukeDS file UUID.
 - url - The `source` field must be a url of a file to download.
 - write - The `source` field must be data to be writen to a file.
-- unzip - Unzip `source` field to `dest`.
+
+All types have an optional `unzip_to` field to specify a location to unzip the dowloaded file to.
 
 
 ## Organize Output Project

--- a/lando_util/download.py
+++ b/lando_util/download.py
@@ -1,6 +1,7 @@
 import click
 import json
 import os
+import zipfile
 import urllib.request
 from ddsc.sdk.client import Client as DukeDSClient
 
@@ -34,6 +35,12 @@ def download_files(dds_client, stage_items):
             click.echo("Writing file {}.".format(dest))
             with open(dest, 'w') as outfile:
                 outfile.write(source)
+        elif type == "unzip":
+            click.echo("Unzip file {} to {}.".format(source, dest))
+            with zipfile.ZipFile(source) as z:
+                z.extractall(dest)
+        else:
+            raise ValueError("Unsupported type {}".format(type))
     click.echo("Staging complete.".format(len(stage_items)))
     return downloaded_metadata_items
 

--- a/lando_util/organize_project/organizer.py
+++ b/lando_util/organize_project/organizer.py
@@ -44,6 +44,7 @@ class Settings(object):
         self.bespin_job_id = data['bespin_job_id']  # bespin job id of the job this output project is for
         self.destination_dir = data['destination_dir']  # directory where we will add files/folders
         self.workflow_path = data['workflow_path']  # path to downloaded workflow either a zip file or packed cwl
+        self.workflow_to_read = data['workflow_to_read']  # path to where the workflow main file can be read
         self.workflow_type = data['workflow_type']  # format of workflow file ('zipped' or 'packed')
         self.job_order_path = data['job_order_path']  # path to job order used when running the workflow
         self.bespin_workflow_stdout_path = data['bespin_workflow_stdout_path']  # path to stdout created by CWL runner
@@ -104,7 +105,7 @@ class Settings(object):
 
 class ProjectData(object):
     def __init__(self, settings):
-        self.workflow_info = create_workflow_info(workflow_path=settings.workflow_path)
+        self.workflow_info = create_workflow_info(settings.workflow_to_read)
         self.workflow_info.update_with_job_order(job_order_path=settings.job_order_path)
         self.workflow_info.update_with_job_output(job_output_path=settings.bespin_workflow_stdout_path)
         run_time = "{} minutes".format(settings.bespin_workflow_elapsed_minutes)

--- a/lando_util/organize_project/organizer.py
+++ b/lando_util/organize_project/organizer.py
@@ -43,7 +43,7 @@ class Settings(object):
         data = json.load(cmdfile)
         self.bespin_job_id = data['bespin_job_id']  # bespin job id of the job this output project is for
         self.destination_dir = data['destination_dir']  # directory where we will add files/folders
-        self.workflow_path = data['workflow_path']  # path to downloaded workflow either a zip file or packed cwl
+        self.downloaded_workflow_path = data['downloaded_workflow_path']  # path to downloaded workflow (zip/packed cwl)
         self.workflow_to_read = data['workflow_to_read']  # path to where the workflow main file can be read
         self.workflow_type = data['workflow_type']  # format of workflow file ('zipped' or 'packed')
         self.job_order_path = data['job_order_path']  # path to job order used when running the workflow
@@ -87,7 +87,7 @@ class Settings(object):
 
     @property
     def workflow_dest_path(self):
-        return os.path.join(self.scripts_dir, os.path.basename(self.workflow_path))
+        return os.path.join(self.scripts_dir, os.path.basename(self.downloaded_workflow_path))
 
     @property
     def job_order_dest_path(self):
@@ -149,9 +149,9 @@ class Organizer(object):
 
         # copy docs/scripts cwl workflow file
         if self.settings.workflow_type == 'packed':
-            shutil.copy(self.settings.workflow_path, self.settings.workflow_dest_path)
+            shutil.copy(self.settings.downloaded_workflow_path, self.settings.workflow_dest_path)
         elif self.settings.workflow_type == 'zipped':
-            with zipfile.ZipFile(self.settings.workflow_path) as z:
+            with zipfile.ZipFile(self.settings.downloaded_workflow_path) as z:
                 z.extractall(self.settings.workflow_dest_path)
         else:
             raise ValueError("Unknown workflow type {}".format(self.settings.workflow_type))

--- a/lando_util/organize_project/organizer.py
+++ b/lando_util/organize_project/organizer.py
@@ -18,6 +18,7 @@ results/           # this directory is uploaded in the store output stage (desti
 import os
 import json
 import shutil
+import zipfile
 import click
 import dateutil.parser
 from lando_util.organize_project.reports import ReadmeReport, create_workflow_info
@@ -42,7 +43,8 @@ class Settings(object):
         data = json.load(cmdfile)
         self.bespin_job_id = data['bespin_job_id']  # bespin job id of the job this output project is for
         self.destination_dir = data['destination_dir']  # directory where we will add files/folders
-        self.workflow_path = data['workflow_path']  # path to the workflow we ran
+        self.workflow_path = data['workflow_path']  # path to downloaded workflow either a zip file or packed cwl
+        self.workflow_type = data['workflow_type']  # format of workflow file ('zipped' or 'packed')
         self.job_order_path = data['job_order_path']  # path to job order used when running the workflow
         self.bespin_workflow_stdout_path = data['bespin_workflow_stdout_path']  # path to stdout created by CWL runner
         self.bespin_workflow_stderr_path = data['bespin_workflow_stderr_path']  # path to stderr created by CWL runner
@@ -145,7 +147,13 @@ class Organizer(object):
         )
 
         # copy docs/scripts cwl workflow file
-        shutil.copy(self.settings.workflow_path, self.settings.workflow_dest_path)
+        if self.settings.workflow_type == 'packed':
+            shutil.copy(self.settings.workflow_path, self.settings.workflow_dest_path)
+        elif self.settings.workflow_type == 'zipped':
+            with zipfile.ZipFile(self.settings.workflow_path) as z:
+                z.extractall(self.settings.workflow_dest_path)
+        else:
+            raise ValueError("Unknown workflow type {}".format(self.settings.workflow_type))
         # copy docs/scripts job order file
         shutil.copy(self.settings.job_order_path, self.settings.job_order_dest_path)
         # copy docs/logs bespin workflow stdout

--- a/lando_util/organize_project/reports.py
+++ b/lando_util/organize_project/reports.py
@@ -83,7 +83,7 @@ def get_documentation_str(node):
 def create_workflow_info(workflow_path):
     """
     Create a workflow_info filling in data based on a cwl workflow.
-    :param workflow_path: str: packed cwl workflow
+    :param workflow_path: str: cwl workflow file
     :return: WorkflowInfo
     """
     doc = parse_yaml_or_json(workflow_path)

--- a/lando_util/organize_project/reports.py
+++ b/lando_util/organize_project/reports.py
@@ -80,25 +80,25 @@ def get_documentation_str(node):
     return documentation
 
 
-def create_workflow_info(workflow_path):
+def create_workflow_info(local_workflow_path):
     """
     Create a workflow_info filling in data based on a cwl workflow.
-    :param workflow_path: str: packed cwl workflow
+    :param local_workflow_path: str: packed cwl workflow
     :return: WorkflowInfo
     """
-    doc = parse_yaml_or_json(workflow_path)
+    doc = parse_yaml_or_json(local_workflow_path)
     cwl_version = doc.get('cwlVersion')
     if doc.get("class") == 'Workflow':
-        return WorkflowInfo(workflow_path, cwl_version, doc)
+        return WorkflowInfo(local_workflow_path, cwl_version, doc)
     else:
         graph = doc.get("$graph")
         if graph:
             for node in graph:
                 if node.get("id") == "#main":
-                    return WorkflowInfo(workflow_path, cwl_version, node)
+                    return WorkflowInfo(local_workflow_path, cwl_version, node)
         if doc.get("id") == "#main":
-            return WorkflowInfo(workflow_path, cwl_version, doc)
-    raise ValueError("Unable to read {} as CWL".format(workflow_path))
+            return WorkflowInfo(local_workflow_path, cwl_version, doc)
+    raise ValueError("Unable to read {} as CWL".format(local_workflow_path))
 
 
 def upconvert_to_list(list_or_dict):

--- a/lando_util/organize_project/reports.py
+++ b/lando_util/organize_project/reports.py
@@ -82,20 +82,23 @@ def get_documentation_str(node):
 
 def create_workflow_info(workflow_path):
     """
-    Create a workflow_info filling in data based on a packed cwl workflow.
+    Create a workflow_info filling in data based on a cwl workflow.
     :param workflow_path: str: packed cwl workflow
     :return: WorkflowInfo
     """
     doc = parse_yaml_or_json(workflow_path)
     cwl_version = doc.get('cwlVersion')
-    graph = doc.get("$graph")
-    if graph:
-        for node in graph:
-            if node.get("id") == "#main":
-                return WorkflowInfo(workflow_path, cwl_version, node)
-    if doc.get("id") == "#main":
+    if doc.get("class") == 'Workflow':
         return WorkflowInfo(workflow_path, cwl_version, doc)
-    raise ValueError("Unable to find #main in {}".format(workflow_path))
+    else:
+        graph = doc.get("$graph")
+        if graph:
+            for node in graph:
+                if node.get("id") == "#main":
+                    return WorkflowInfo(workflow_path, cwl_version, node)
+        if doc.get("id") == "#main":
+            return WorkflowInfo(workflow_path, cwl_version, doc)
+    raise ValueError("Unable to read {} as CWL".format(workflow_path))
 
 
 class WorkflowInfo(object):

--- a/lando_util/organize_project/reports.py
+++ b/lando_util/organize_project/reports.py
@@ -83,7 +83,7 @@ def get_documentation_str(node):
 def create_workflow_info(workflow_path):
     """
     Create a workflow_info filling in data based on a cwl workflow.
-    :param workflow_path: str: cwl workflow file
+    :param workflow_path: str: packed cwl workflow
     :return: WorkflowInfo
     """
     doc = parse_yaml_or_json(workflow_path)
@@ -99,6 +99,24 @@ def create_workflow_info(workflow_path):
         if doc.get("id") == "#main":
             return WorkflowInfo(workflow_path, cwl_version, doc)
     raise ValueError("Unable to read {} as CWL".format(workflow_path))
+
+
+def upconvert_to_list(list_or_dict):
+    """
+    Packed CWL workflow inputs/outputs are structured as lists of dicts (e.g.
+    [{'id': 'input_file', 'type': 'File'},...]). Unpacked workflows may have
+    dicts (e.g. {'input_file': 'File'}. This function converts the dicts into
+    lists of dicts or returns the list
+
+    :param list_or_dict:
+    :return:
+    """
+    if isinstance(list_or_dict, list):
+        return list_or_dict
+    elif isinstance(list_or_dict, dict):
+        return [{'id': k, 'type': v} for k,v in list_or_dict.items()]
+    else:
+        raise ValueError('Only list or dict are supported, not {}', type(list_or_dict))
 
 
 class WorkflowInfo(object):
@@ -118,9 +136,9 @@ class WorkflowInfo(object):
         self.documentation = get_documentation_str(workflow_node)
         self.input_params = []
         self.output_data = []
-        for input_param in workflow_node.get("inputs"):
+        for input_param in upconvert_to_list(workflow_node.get('inputs')):
             self.input_params.append(InputParam(input_param))
-        for output_param in workflow_node.get("outputs"):
+        for output_param in upconvert_to_list(workflow_node.get("outputs")):
             self.output_data.append(OutputData(output_param))
 
     def update_with_job_order(self, job_order_path):

--- a/lando_util/organize_project/tests/test_organizer.py
+++ b/lando_util/organize_project/tests/test_organizer.py
@@ -19,7 +19,7 @@ class TestSettings(TestCase):
         self.settings_packed_dict = {
             "bespin_job_id": "1",
             "destination_dir": 'somedir',
-            "workflow_path": '/workflow/sort.cwl',
+            "downloaded_workflow_path": '/workflow/sort.cwl',
             "workflow_to_read": '/workflow/read/sort.cwl',
             "workflow_type": "packed",
             "job_order_path": '/output/job_order.json',
@@ -35,7 +35,7 @@ class TestSettings(TestCase):
         self.settings_zipped_dict = {
             "bespin_job_id": "1",
             "destination_dir": 'somedir',
-            "workflow_path": '/workflow/sort.cwl',
+            "downloaded_workflow_path": '/workflow/sort.cwl',
             "workflow_to_read": '/workflow/read/sort.zip',
             "workflow_type": "zipped",
             "job_order_path": '/output/job_order.json',
@@ -66,7 +66,7 @@ class TestSettings(TestCase):
         self.assertEqual(settings.job_order_dest_path, 'somedir/docs/scripts/job_order.json')
         self.assertEqual(settings.bespin_workflow_elapsed_minutes, 15.0)
         self.assertEqual(settings.additional_log_files, ["/bespin/output-data/job-51-bob-resource-usage.json"])
-        self.assertEqual(settings.workflow_path, '/workflow/sort.cwl')
+        self.assertEqual(settings.downloaded_workflow_path, '/workflow/sort.cwl')
         self.assertEqual(settings.workflow_to_read, '/workflow/read/sort.cwl')
         self.assertEqual(settings.workflow_type, 'packed')
 
@@ -87,7 +87,7 @@ class TestSettings(TestCase):
         self.assertEqual(settings.job_order_dest_path, 'somedir/docs/scripts/job_order.json')
         self.assertEqual(settings.bespin_workflow_elapsed_minutes, 15.0)
         self.assertEqual(settings.additional_log_files, ["/bespin/output-data/job-51-bob-resource-usage.json"])
-        self.assertEqual(settings.workflow_path, '/workflow/sort.cwl')
+        self.assertEqual(settings.downloaded_workflow_path, '/workflow/sort.cwl')
         self.assertEqual(settings.workflow_to_read, '/workflow/read/sort.zip')
         self.assertEqual(settings.workflow_type, 'zipped')
 
@@ -120,7 +120,7 @@ class TestProjectData(TestCase):
             bespin_workflow_finished='2019-02-09T12:45',
             bespin_workflow_elapsed_minutes='120',
             workflow_to_read='/input/read/workflow.cwl',
-            workflow_path='/input/sort.cwl',
+            downloaded_workflow_path='/input/sort.cwl',
             job_order_path='/data/job_order.json',
             bespin_workflow_stdout_path='/output/workflow_stdout.json',
             methods_template='#Markdown'
@@ -181,7 +181,7 @@ class TestOrganizer(TestCase):
             call(exist_ok=True, name=mock_settings.logs_dir),
         ])
         mock_shutil.copy.assert_has_calls([
-            call(mock_settings.workflow_path, mock_settings.workflow_dest_path),
+            call(mock_settings.downloaded_workflow_path, mock_settings.workflow_dest_path),
             call(mock_settings.job_order_path, mock_settings.job_order_dest_path),
             call(mock_settings.bespin_workflow_stdout_path, mock_settings.bespin_workflow_stdout_dest_path),
             call(mock_settings.bespin_workflow_stderr_path, mock_settings.bespin_workflow_stderr_dest_path),
@@ -210,7 +210,7 @@ class TestOrganizer(TestCase):
         mock_settings.bespin_workflow_started = '2019-02-07T12:30'
         mock_settings.bespin_workflow_finished = '2019-02-09T12:45'
         mock_settings.bespin_workflow_elapsed_minutes = '120'
-        mock_settings.workflow_path = '/workflow/workflow.zip'
+        mock_settings.downloaded_workflow_path = '/workflow/workflow.zip'
         mock_settings.workflow_dest_path = '/workflow/outdir'
         mock_settings.logs_dir = '/results/docs/logs/'
         mock_settings.additional_log_files = ['/tmp/extra/usage-report.txt', '/data/log2.txt']

--- a/lando_util/organize_project/tests/test_organizer.py
+++ b/lando_util/organize_project/tests/test_organizer.py
@@ -20,6 +20,7 @@ class TestSettings(TestCase):
             "bespin_job_id": "1",
             "destination_dir": 'somedir',
             "workflow_path": '/workflow/sort.cwl',
+            "workflow_type": "packed",
             "job_order_path": '/output/job_order.json',
             "bespin_workflow_stdout_path": '/output/workflow-output.json',
             "bespin_workflow_stderr_path": '/output/workflow-output.log',
@@ -112,6 +113,7 @@ class TestOrganizer(TestCase):
     @patch('lando_util.organize_project.organizer.write_data_to_file')
     def test_run(self, mock_write_data_to_file, mock_project_data, mock_shutil, mock_os):
         mock_settings = Mock()
+        mock_settings.workflow_type = 'packed'
         mock_settings.bespin_job_id = '42'
         mock_settings.bespin_workflow_started = '2019-02-07T12:30'
         mock_settings.bespin_workflow_finished = '2019-02-09T12:45'

--- a/lando_util/organize_project/tests/test_organizer.py
+++ b/lando_util/organize_project/tests/test_organizer.py
@@ -20,6 +20,7 @@ class TestSettings(TestCase):
             "bespin_job_id": "1",
             "destination_dir": 'somedir',
             "workflow_path": '/workflow/sort.cwl',
+            "workflow_to_read": '/workflow/read/sort.cwl',
             "workflow_type": "packed",
             "job_order_path": '/output/job_order.json',
             "bespin_workflow_stdout_path": '/output/workflow-output.json',

--- a/lando_util/organize_project/tests/test_organizer.py
+++ b/lando_util/organize_project/tests/test_organizer.py
@@ -16,7 +16,7 @@ class TestOrganizerFuncs(TestCase):
 
 class TestSettings(TestCase):
     def setUp(self):
-        self.settings_dict = {
+        self.settings_packed_dict = {
             "bespin_job_id": "1",
             "destination_dir": 'somedir',
             "workflow_path": '/workflow/sort.cwl',
@@ -32,10 +32,26 @@ class TestSettings(TestCase):
                 "/bespin/output-data/job-51-bob-resource-usage.json",
             ]
         }
+        self.settings_zipped_dict = {
+            "bespin_job_id": "1",
+            "destination_dir": 'somedir',
+            "workflow_path": '/workflow/sort.cwl',
+            "workflow_to_read": '/workflow/read/sort.zip',
+            "workflow_type": "zipped",
+            "job_order_path": '/output/job_order.json',
+            "bespin_workflow_stdout_path": '/output/workflow-output.json',
+            "bespin_workflow_stderr_path": '/output/workflow-output.log',
+            "bespin_workflow_started": "2019-02-07T12:30",
+            "bespin_workflow_finished": "2019-02-07T12:45",
+            "methods_template": '#replace stuff',
+            "additional_log_files": [
+                "/bespin/output-data/job-51-bob-resource-usage.json",
+            ]
+        }
 
     @patch('lando_util.organize_project.organizer.json')
-    def test_properties(self, mock_json):
-        mock_json.load.return_value = self.settings_dict
+    def test_packed_properties(self, mock_json):
+        mock_json.load.return_value = self.settings_packed_dict
         mock_cmdfile = Mock()
         settings = Settings(mock_cmdfile)
         self.assertEqual(settings.docs_dir, 'somedir/docs')
@@ -50,21 +66,45 @@ class TestSettings(TestCase):
         self.assertEqual(settings.job_order_dest_path, 'somedir/docs/scripts/job_order.json')
         self.assertEqual(settings.bespin_workflow_elapsed_minutes, 15.0)
         self.assertEqual(settings.additional_log_files, ["/bespin/output-data/job-51-bob-resource-usage.json"])
+        self.assertEqual(settings.workflow_path, '/workflow/sort.cwl')
+        self.assertEqual(settings.workflow_to_read, '/workflow/read/sort.cwl')
+        self.assertEqual(settings.workflow_type, 'packed')
+
+    @patch('lando_util.organize_project.organizer.json')
+    def test_zipped_properties(self, mock_json):
+        mock_json.load.return_value = self.settings_zipped_dict
+        mock_cmdfile = Mock()
+        settings = Settings(mock_cmdfile)
+        self.assertEqual(settings.docs_dir, 'somedir/docs')
+        self.assertEqual(settings.readme_md_dest_path, 'somedir/docs/README.md')
+        self.assertEqual(settings.readme_html_dest_path, 'somedir/docs/README.html')
+        self.assertEqual(settings.logs_dir, 'somedir/docs/logs')
+        self.assertEqual(settings.bespin_workflow_stdout_dest_path, 'somedir/docs/logs/bespin-workflow-output.json')
+        self.assertEqual(settings.bespin_workflow_stderr_dest_path, 'somedir/docs/logs/bespin-workflow-output.log')
+        self.assertEqual(settings.job_data_dest_path, 'somedir/docs/logs/job-data.json')
+        self.assertEqual(settings.scripts_dir, 'somedir/docs/scripts')
+        self.assertEqual(settings.workflow_dest_path, 'somedir/docs/scripts/sort.cwl')
+        self.assertEqual(settings.job_order_dest_path, 'somedir/docs/scripts/job_order.json')
+        self.assertEqual(settings.bespin_workflow_elapsed_minutes, 15.0)
+        self.assertEqual(settings.additional_log_files, ["/bespin/output-data/job-51-bob-resource-usage.json"])
+        self.assertEqual(settings.workflow_path, '/workflow/sort.cwl')
+        self.assertEqual(settings.workflow_to_read, '/workflow/read/sort.zip')
+        self.assertEqual(settings.workflow_type, 'zipped')
 
     @patch('lando_util.organize_project.organizer.json')
     def test_bespin_workflow_elapsed_minutes(self, mock_json):
-        self.settings_dict['bespin_workflow_started'] = '2019-02-07T12:30'
-        self.settings_dict['bespin_workflow_finished'] = '2019-02-09T12:30'
-        mock_json.load.return_value = self.settings_dict
+        self.settings_packed_dict['bespin_workflow_started'] = '2019-02-07T12:30'
+        self.settings_packed_dict['bespin_workflow_finished'] = '2019-02-09T12:30'
+        mock_json.load.return_value = self.settings_packed_dict
         mock_cmdfile = Mock()
         settings = Settings(mock_cmdfile)
         self.assertEqual(settings.bespin_workflow_elapsed_minutes, 2 * 24 * 60)
 
     @patch('lando_util.organize_project.organizer.json')
     def test_bespin_workflow_elapsed_minutes_is_optional(self, mock_json):
-        del self.settings_dict['bespin_workflow_started']
-        del self.settings_dict['bespin_workflow_finished']
-        mock_json.load.return_value = self.settings_dict
+        del self.settings_packed_dict['bespin_workflow_started']
+        del self.settings_packed_dict['bespin_workflow_finished']
+        mock_json.load.return_value = self.settings_packed_dict
         mock_cmdfile = Mock()
         settings = Settings(mock_cmdfile)
         self.assertEqual(settings.bespin_workflow_elapsed_minutes, 0)

--- a/lando_util/organize_project/tests/test_reports.py
+++ b/lando_util/organize_project/tests/test_reports.py
@@ -207,7 +207,7 @@ class TestCwlReportUtilities(TestCase):
         mock_parse_yaml_or_json.return_value = {}
         with self.assertRaises(ValueError) as err:
             create_workflow_info('/tmp/fakepath.cwl')
-        self.assertEqual("Unable to find #main in /tmp/fakepath.cwl", str(err.exception))
+        self.assertEqual("Unable to read /tmp/fakepath.cwl as CWL", str(err.exception))
 
     @patch("lando_util.organize_project.reports.parse_yaml_or_json")
     def test_create_workflow_info_with_top_level_graph(self, mock_parse_yaml_or_json):

--- a/lando_util/stagedata.py
+++ b/lando_util/stagedata.py
@@ -17,30 +17,30 @@ def get_stage_items(cmdfile):
     return items
 
 
-def download_files(dds_client, stage_items):
+def stage_data(dds_client, stage_items):
     downloaded_metadata_items = []
     click.echo("Staging {} items.".format(len(stage_items)))
-    for type, source, dest in stage_items:
+    for item_type, source, dest in stage_items:
         parent_directory = os.path.dirname(dest)
         os.makedirs(parent_directory, exist_ok=True)
-        if type == "DukeDS":
+        if item_type == "DukeDS":
             click.echo("Downloading DukeDS file {} to {}.".format(source, dest))
             dds_file = dds_client.get_file_by_id(file_id=source)
             dds_file.download_to_path(dest)
             downloaded_metadata_items.append(dds_file._data_dict)
-        elif type == "url":
+        elif item_type == "url":
             click.echo("Downloading URL {} to {}.".format(source, dest))
             urllib.request.urlretrieve(source, dest)
-        elif type == "write":
+        elif item_type == "write":
             click.echo("Writing file {}.".format(dest))
             with open(dest, 'w') as outfile:
                 outfile.write(source)
-        elif type == "unzip":
+        elif item_type == "unzip":
             click.echo("Unzip file {} to {}.".format(source, dest))
             with zipfile.ZipFile(source) as z:
                 z.extractall(dest)
         else:
-            raise ValueError("Unsupported type {}".format(type))
+            raise ValueError("Unsupported type {}".format(item_type))
     click.echo("Staging complete.".format(len(stage_items)))
     return downloaded_metadata_items
 
@@ -58,7 +58,7 @@ def write_downloaded_metadata(outfile, downloaded_metadata_items):
 def main(cmdfile, downloaded_metadata_file):
     dds_client = DukeDSClient()
     stage_items = get_stage_items(cmdfile)
-    downloaded_metadata_items = download_files(dds_client, stage_items)
+    downloaded_metadata_items = stage_data(dds_client, stage_items)
     if downloaded_metadata_file:
         write_downloaded_metadata(downloaded_metadata_file, downloaded_metadata_items)
 

--- a/lando_util/stagedata.py
+++ b/lando_util/stagedata.py
@@ -25,25 +25,43 @@ def stage_data(dds_client, stage_items):
         parent_directory = os.path.dirname(dest)
         os.makedirs(parent_directory, exist_ok=True)
         if item_type == "DukeDS":
-            click.echo("Downloading DukeDS file {} to {}.".format(source, dest))
-            dds_file = dds_client.get_file_by_id(file_id=source)
-            dds_file.download_to_path(dest)
-            downloaded_metadata_items.append(dds_file._data_dict)
+            metadata_item = download_dukeds_file(dds_client, source, dest)
+            downloaded_metadata_items.append(metadata_item)
         elif item_type == "url":
-            click.echo("Downloading URL {} to {}.".format(source, dest))
-            urllib.request.urlretrieve(source, dest)
+            download_url(source, dest)
         elif item_type == "write":
-            click.echo("Writing file {}.".format(dest))
-            with open(dest, 'w') as outfile:
-                outfile.write(source)
+            write_file(source, dest)
         else:
             raise ValueError("Unsupported type {}".format(item_type))
         if unzip_to:
-            click.echo("Unzip file {} to {}.".format(dest, unzip_to))
-            with zipfile.ZipFile(dest) as z:
-                z.extractall(unzip_to)
+            # if specified unzip downloaded file to `unzip_to` location
+            unzip(dest, unzip_to)
     click.echo("Staging complete.".format(len(stage_items)))
     return downloaded_metadata_items
+
+
+def download_dukeds_file(dds_client, source, dest):
+    click.echo("Downloading DukeDS file {} to {}.".format(source, dest))
+    dds_file = dds_client.get_file_by_id(file_id=source)
+    dds_file.download_to_path(dest)
+    return dds_file._data_dict
+
+
+def download_url(source, dest):
+    click.echo("Downloading URL {} to {}.".format(source, dest))
+    urllib.request.urlretrieve(source, dest)
+
+
+def write_file(source, dest):
+    click.echo("Writing file {}.".format(dest))
+    with open(dest, 'w') as outfile:
+        outfile.write(source)
+
+
+def unzip(source, dest):
+    click.echo("Unzip file {} to {}.".format(source, dest))
+    with zipfile.ZipFile(source) as z:
+        z.extractall(dest)
 
 
 def write_downloaded_metadata(outfile, downloaded_metadata_items):

--- a/lando_util/stagedata.py
+++ b/lando_util/stagedata.py
@@ -10,17 +10,18 @@ def get_stage_items(cmdfile):
     data = json.load(cmdfile)
     items = []
     for file_data in data['items']:
-        type = file_data['type']
+        item_type = file_data['type']
         source = file_data['source']
         dest = file_data['dest']
-        items.append((type, source, dest))
+        unzip_to = file_data.get('unzip_to')
+        items.append((item_type, source, dest, unzip_to))
     return items
 
 
 def stage_data(dds_client, stage_items):
     downloaded_metadata_items = []
     click.echo("Staging {} items.".format(len(stage_items)))
-    for item_type, source, dest in stage_items:
+    for item_type, source, dest, unzip_to in stage_items:
         parent_directory = os.path.dirname(dest)
         os.makedirs(parent_directory, exist_ok=True)
         if item_type == "DukeDS":
@@ -35,12 +36,12 @@ def stage_data(dds_client, stage_items):
             click.echo("Writing file {}.".format(dest))
             with open(dest, 'w') as outfile:
                 outfile.write(source)
-        elif item_type == "unzip":
-            click.echo("Unzip file {} to {}.".format(source, dest))
-            with zipfile.ZipFile(source) as z:
-                z.extractall(dest)
         else:
             raise ValueError("Unsupported type {}".format(item_type))
+        if unzip_to:
+            click.echo("Unzip file {} to {}.".format(dest, unzip_to))
+            with zipfile.ZipFile(dest) as z:
+                z.extractall(unzip_to)
     click.echo("Staging complete.".format(len(stage_items)))
     return downloaded_metadata_items
 

--- a/lando_util/tests/test_stagedata.py
+++ b/lando_util/tests/test_stagedata.py
@@ -2,11 +2,11 @@ import os
 import json
 from unittest import TestCase
 from unittest.mock import patch, Mock, call
-from lando_util.download import get_stage_items, download_files, write_downloaded_metadata, main
+from lando_util.stagedata import get_stage_items, stage_data, write_downloaded_metadata, main
 
 
 class TestDownloadFunctions(TestCase):
-    @patch('lando_util.download.json')
+    @patch('lando_util.stagedata.json')
     def test_get_stage_items(self, mock_json):
         mock_json.load.return_value = {
             "items": [
@@ -29,12 +29,12 @@ class TestDownloadFunctions(TestCase):
         self.assertEqual(result[3], ("url", "myfile.zip", "/data/myfile.zip"))
         self.assertEqual(result[4], ("unzip", "/data/myfile.zip", "/data"))
 
-    @patch("lando_util.download.os")
-    @patch("lando_util.download.urllib")
-    @patch("lando_util.download.zipfile")
+    @patch("lando_util.stagedata.os")
+    @patch("lando_util.stagedata.urllib")
+    @patch("lando_util.stagedata.zipfile")
     @patch("builtins.open")
-    @patch("lando_util.download.click")
-    def test_download_files(self, mock_click, mock_open, mock_zipfile, mock_urllib, mock_os):
+    @patch("lando_util.stagedata.click")
+    def test_stage_data(self, mock_click, mock_open, mock_zipfile, mock_urllib, mock_os):
         mock_os.path.dirname = lambda x: os.path.dirname(x)
         mock_dds_client = Mock()
         mock_dds_client.get_file_by_id.return_value = Mock(_data_dict={"current_version": {"id": "999"}})
@@ -46,7 +46,7 @@ class TestDownloadFunctions(TestCase):
             ("unzip", "/data/myfile.zip", "/data"),
         ]
 
-        result = download_files(mock_dds_client, stage_items)
+        result = stage_data(mock_dds_client, stage_items)
 
         mock_click.echo.assert_has_calls([
             call("Staging 5 items."),
@@ -78,17 +78,17 @@ class TestDownloadFunctions(TestCase):
         mock_zipfile.ZipFile.assert_called_with("/data/myfile.zip")
         mock_zipfile.ZipFile.return_value.__enter__.return_value.extractall.assert_called_with("/data")
 
-    @patch("lando_util.download.os")
-    def test_download_files_with_unknown_type(self, mock_os):
+    @patch("lando_util.stagedata.os")
+    def test_stage_data_with_unknown_type(self, mock_os):
         mock_dds_client = Mock()
         stage_items = [
             ("faketype", "123456", "/data/file1.dat")
         ]
         with self.assertRaises(ValueError) as raised_exception:
-            download_files(mock_dds_client, stage_items)
+            stage_data(mock_dds_client, stage_items)
         self.assertEqual(str(raised_exception.exception), 'Unsupported type faketype')
 
-    @patch("lando_util.download.click")
+    @patch("lando_util.stagedata.click")
     def test_write_downloaded_metadata_writes_json_file(self, mock_click):
         mock_outfile = Mock()
         mock_outfile.name = "myoutfile.json"
@@ -105,25 +105,25 @@ class TestDownloadFunctions(TestCase):
             ]
         }))
 
-    @patch('lando_util.download.DukeDSClient')
-    @patch('lando_util.download.get_stage_items')
-    @patch('lando_util.download.download_files')
-    @patch('lando_util.download.write_downloaded_metadata')
-    def test_main_without_downloaded_metadata_file(self, mock_write_downloaded_metadata, mock_download_files,
+    @patch('lando_util.stagedata.DukeDSClient')
+    @patch('lando_util.stagedata.get_stage_items')
+    @patch('lando_util.stagedata.stage_data')
+    @patch('lando_util.stagedata.write_downloaded_metadata')
+    def test_main_without_downloaded_metadata_file(self, mock_write_downloaded_metadata, mock_stage_data,
                                                    mock_get_stage_items, mock_duke_ds_client):
         mock_cmdfile = Mock()
 
         main.callback(mock_cmdfile, None)
 
         mock_get_stage_items.assert_called_with(mock_cmdfile)
-        mock_download_files.assert_called_with(mock_duke_ds_client.return_value, mock_get_stage_items.return_value)
+        mock_stage_data.assert_called_with(mock_duke_ds_client.return_value, mock_get_stage_items.return_value)
         mock_write_downloaded_metadata.assert_not_called()
 
-    @patch('lando_util.download.DukeDSClient')
-    @patch('lando_util.download.get_stage_items')
-    @patch('lando_util.download.download_files')
-    @patch('lando_util.download.write_downloaded_metadata')
-    def test_main_with_downloaded_metadata_file(self, mock_write_downloaded_metadata, mock_download_files,
+    @patch('lando_util.stagedata.DukeDSClient')
+    @patch('lando_util.stagedata.get_stage_items')
+    @patch('lando_util.stagedata.stage_data')
+    @patch('lando_util.stagedata.write_downloaded_metadata')
+    def test_main_with_downloaded_metadata_file(self, mock_write_downloaded_metadata, mock_stage_data,
                                                    mock_get_stage_items, mock_duke_ds_client):
         mock_cmdfile = Mock()
         mock_metadata_file = Mock()
@@ -131,5 +131,5 @@ class TestDownloadFunctions(TestCase):
         main.callback(mock_cmdfile, mock_metadata_file)
 
         mock_get_stage_items.assert_called_with(mock_cmdfile)
-        mock_download_files.assert_called_with(mock_duke_ds_client.return_value, mock_get_stage_items.return_value)
-        mock_write_downloaded_metadata.assert_called_with(mock_metadata_file, mock_download_files.return_value)
+        mock_stage_data.assert_called_with(mock_duke_ds_client.return_value, mock_get_stage_items.return_value)
+        mock_write_downloaded_metadata.assert_called_with(mock_metadata_file, mock_stage_data.return_value)


### PR DESCRIPTION
- renames `download` command to `stagedata` to better model what it does
- adds `unzip_to` optional field to all `stagedata` item types to to unzip workflows
- adds `workflow_to_read` and `workflow_type ` to `organize_project` command
- renames `workflow_path` to `downloaded_workflow_path` to better describe what it represents
- `organize_project` will unzip zipped workflows to results directory following the pattern from [lando](https://github.com/Duke-GCB/lando/blob/c644add467f3b6bb40ef24a8f701d6f407f9543c/lando/worker/cwlworkflow.py#L120-L121)


This PR needed by https://github.com/Duke-GCB/lando/pull/196