### PR TITLE
upload command option to record project details in JSON file

### DIFF
--- a/lando_util/tests/test_upload.py
+++ b/lando_util/tests/test_upload.py
@@ -168,6 +168,17 @@ class TestUploadUtil(TestCase):
         util.create_annotate_project_details_script(mock_project, mock_outfile)
         mock_outfile.write.assert_called_with('kubectl annotate pod $MY_POD_NAME project_id=888 readme_file_id=999')
 
+    def test_create_json_project_details_file(self, mock_duke_ds_client, mock_settings):
+        util = UploadUtil(Mock())
+        mock_project = Mock()
+        mock_project.id = '888'
+        mock_readme_file = Mock()
+        mock_readme_file.id = '999'
+        mock_project.get_child_for_path.return_value = mock_readme_file
+        mock_outfile = Mock()
+        util.create_json_project_details_file(mock_project, mock_outfile)
+        mock_outfile.write.assert_called_with(json.dumps({"project_id": "888", "readme_file_id": "999"}))
+
 
 class TestMain(TestCase):
     @patch('lando_util.upload.UploadUtil')

--- a/lando_util/tests/test_upload.py
+++ b/lando_util/tests/test_upload.py
@@ -171,11 +171,11 @@ class TestUploadUtil(TestCase):
 
 class TestMain(TestCase):
     @patch('lando_util.upload.UploadUtil')
-    def test_main(self, mock_upload_util):
+    def test_main_outfile_annotate_script(self, mock_upload_util):
         mock_cmdfile = Mock()
         mock_outfile = Mock()
 
-        main.callback(mock_cmdfile, mock_outfile)
+        main.callback(mock_cmdfile, mock_outfile, "annotate_script")
 
         mock_upload_util.assert_called_with(mock_cmdfile)
         upload_util = mock_upload_util.return_value
@@ -187,6 +187,25 @@ class TestMain(TestCase):
         upload_util.share_project.assert_called_with(mock_project)
         upload_util.create_annotate_project_details_script.assert_called_with(
             mock_project, mock_outfile)
+        upload_util.create_json_project_details_file.assert_not_called()
+
+    @patch('lando_util.upload.UploadUtil')
+    def test_main_outfile_json(self, mock_upload_util):
+        mock_cmdfile = Mock()
+        mock_outfile = Mock()
+
+        main.callback(mock_cmdfile, mock_outfile, "json")
+
+        mock_upload_util.assert_called_with(mock_cmdfile)
+        upload_util = mock_upload_util.return_value
+        upload_util.get_or_create_project.assert_called_with()
+        mock_project = upload_util.get_or_create_project.return_value
+        upload_util.create_provenance_activity.assert_called_with(
+            upload_util.upload_files.return_value
+        )
+        upload_util.share_project.assert_called_with(mock_project)
+        upload_util.create_annotate_project_details_script.assert_not_called()
+        upload_util.create_json_project_details_file.assert_called_with(mock_project, mock_outfile)
 
 
 class TestUploadedFilesInfo(TestCase):

--- a/lando_util/upload.py
+++ b/lando_util/upload.py
@@ -209,17 +209,29 @@ class UploadUtil(object):
         outfile.write(contents)
         outfile.close()
 
+    def create_json_project_details_file(self, project, outfile):
+        readme_file = project.get_child_for_path(self.settings.readme_file_path)
+        click.echo("Writing JSON project details project_id:{} readme_file_id:{} to {}".format(
+            project.id, readme_file.id, outfile.name))
+        outfile.write(json.dumps({
+            "project_id": project.id, "readme_file_id": readme_file.id
+        }))
+
 
 @click.command()
 @click.argument('cmdfile', type=click.File('r'))
 @click.argument('outfile', type=click.File('w'))
-def main(cmdfile, outfile):
+@click.option('--outfile-format', type=click.Choice(['annotate_script', 'json']), default='annotate_script')
+def main(cmdfile, outfile, outfile_format):
     util = UploadUtil(cmdfile)
     project = util.get_or_create_project()
     uploaded_files_info = util.upload_files(project)
     util.create_provenance_activity(uploaded_files_info)
     util.share_project(project)
-    util.create_annotate_project_details_script(project, outfile)
+    if outfile_format == 'annotate_script':
+        util.create_annotate_project_details_script(project, outfile)
+    elif outfile_format == 'json':
+        util.create_json_project_details_file(project, outfile)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The upload command writes an output file that contains the project id and readme file id.
Before this PR the outfile format was always a script to annotate a k8s pod with these values.
To allow [use of lando-util from a lando VM](https://github.com/Duke-GCB/lando/issues/154) this PR adds an optional `--outfile-format` flag that lets user specify what format the output file should be written in. The two outfile supported formats are now `annotate_script` and 'json':
- `annotate_script` - creates a script to annotate a k8s pod with project id and readme file id
- `json` - creates a json file containing the project id and readme file id

The `annotate_script` is the default value to be backwards compatible.