### PR TITLE
Fix circleci setup to deploy releases to pypi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,9 @@ workflows:
           venv_checksum_filename: setup.py
           install_command: python setup.py install
           test_command: python setup.py test
+          filters:
+            tags:
+              only: /.*/
       - python/pypi:
           venv_checksum_filename: setup.py
           install_command: python setup.py install


### PR DESCRIPTION
Releases were not being deployed to pypi when circleci ran in response to a new github release.
The `python/pytest` job ran but not the `python/pypi` job.
Changes here add add `filters` to python/pytest.
CircleCI documentation that seems to say this is needed:
> CircleCI does not run workflows for tags unless you explicitly specify tag filters. Additionally, if a job requires any other jobs (directly or indirectly), you must specify tag filters for those jobs

https://circleci.com/docs/2.0/configuration-reference/#filters-1

I tested these changes in a fork of this repo and it worked there.

Fixes #26 